### PR TITLE
Add test for notfound_exit input

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2,79 +2,131 @@ format_version: 1.3.1
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
-    - RELEASE_VERSION: 1.1.0
+  - RELEASE_VERSION: 1.1.0
 workflows:
   audit-this-step:
     steps:
-      - script:
-          inputs:
-            - content: |-
-                #!/bin/bash
-                set -ex
-                stepman audit --step-yml ./step.yml
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+            stepman audit --step-yml ./step.yml
   deps-update:
     steps:
-      - script:
-          title: Dependency update
-          inputs:
-            - content: |
-                #!/bin/bash
-                set -ex
-                go get -u -v github.com/golang/dep/cmd/dep
-                dep ensure -v
-                dep ensure -v -update
+    - script:
+        title: Dependency update
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -ex
+            go get -u -v github.com/golang/dep/cmd/dep
+            dep ensure -v
+            dep ensure -v -update
   test:
     envs:
-      - TEST_FILE_PATH: ./test.txt
-      - ORIGINAL_TEST_FILE_CONTENT: |-
-          this is the first line
-          the second line
-          and finally the third line
-      - REPLACE_THIS: second
-      - REPLACE_WITH: 2nd
-      - EXPECTED_TEST_FILE_CONTENT_AFTER_REPLACE: |-
-          this is the first line
-          the 2nd line
-          and finally the third line
+    - TEST_FILE_PATH: ./test.txt
+    - ORIGINAL_TEST_FILE_CONTENT: |-
+        this is the first line
+        the second line
+        and finally the third line
+    - REPLACE_THIS: second
+    - REPLACE_WITH: 2nd
+    - EXPECTED_TEST_FILE_CONTENT_AFTER_REPLACE: |-
+        this is the first line
+        the 2nd line
+        and finally the third line
     steps:
-      - change-workdir:
-          title: Switch working dir to test / _tmp dir
-          description: |-
-            To prevent step testing issues, like referencing relative
-            files with just './some-file' in the step's code, which would
-            work for testing the step from this directory directly
-            but would break if the step is included in another `bitrise.yml`.
-          run_if: "true"
-          inputs:
-            - path: ./_tmp
-            - is_create_path: true
-      - script@1.1.3:
-          title: generate test input file
-          inputs:
-            - content: |-
-                #!/bin/bash
-                set -ex
+    - change-workdir:
+        title: Switch working dir to test _tmp dir
+        description: |-
+          To prevent step testing issues, like referencing relative
+          files with just './some-file' in the step's code, which would
+          work for testing the step from this directory directly
+          but would break if the step is included in another `bitrise.yml`.
+        run_if: "true"
+        inputs:
+        - path: ./_tmp
+        - is_create_path: true
+    - script:
+        title: Generate test input file
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
 
-                echo -n "$ORIGINAL_TEST_FILE_CONTENT" > "$TEST_FILE_PATH"
-      - path::./:
-          run_if: "true"
-          inputs:
-            - show_file: "true"
-            - file: $TEST_FILE_PATH
-            - old_value: $REPLACE_THIS
-            - new_value: $REPLACE_WITH
-      - script@1.1.3:
-          title: test the step's output
-          inputs:
-            - content: |-
-                #!/bin/bash
-                set -ex
+            echo -n "$ORIGINAL_TEST_FILE_CONTENT" > "$TEST_FILE_PATH"
+    - path::./:
+        run_if: "true"
+        inputs:
+        - show_file: "true"
+        - file: $TEST_FILE_PATH
+        - old_value: $REPLACE_THIS
+        - new_value: $REPLACE_WITH
+    - script:
+        title: Test the step's output
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
 
-                file_content="$(cat "$TEST_FILE_PATH")"
+            file_content="$(cat "$TEST_FILE_PATH")"
 
-                if [[ "$file_content" != "$EXPECTED_TEST_FILE_CONTENT_AFTER_REPLACE" ]] ; then
-                  echo "Not what we expected!"
-                  exit 1
-                fi
+            if [[ "$file_content" != "$EXPECTED_TEST_FILE_CONTENT_AFTER_REPLACE" ]] ; then
+              echo "Not what we expected!"
+              exit 1
+            fi
 
-                echo "Perfect!"
+            echo "Perfect!"
+
+  test_not_found:
+    steps:
+    - script:
+        title: Start a failing workflow, wrapped in a script.
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            bitrise run utility_test_not_found
+            if [ $? -ne 1 ] ; then
+              echo "Workflow was excepted to fail, exit code not 1."
+              exit 1
+            fi
+
+  utility_test_not_found:
+    envs:
+    - TEST_FILE_PATH: ./test.txt
+    - ORIGINAL_TEST_FILE_CONTENT: |-
+        this is the first line
+
+        and finally the third line
+    - REPLACE_THIS: second
+    - REPLACE_WITH: 2nd
+    steps:
+    - change-workdir:
+        title: Switch working dir to test _tmp dir
+        description: |-
+          To prevent step testing issues, like referencing relative
+          files with just './some-file' in the step's code, which would
+          work for testing the step from this directory directly
+          but would break if the step is included in another `bitrise.yml`.
+        run_if: "true"
+        inputs:
+        - path: ./_tmp
+        - is_create_path: true
+    - script:
+        title: Generate test input file
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+
+            echo -n "$ORIGINAL_TEST_FILE_CONTENT" > "$TEST_FILE_PATH"
+    - path::./:
+        run_if: "true"
+        inputs:
+        - show_file: "true"
+        - file: $TEST_FILE_PATH
+        - old_value: $REPLACE_THIS
+        - new_value: $REPLACE_WITH
+        - notfound_exit: true


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context
* A bug has been fixed that `notfound_exit` worked the other way around: https://github.com/bitrise-steplib/steps-change-value/pull/7.

### Changes
**Added E2E test for `notfound_exit` input.**
