### PR TITLE
Adds support for running with sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | `new_value` | The string that replaces all occurrences of the current value in the target file. | required |  |
 | `show_file` | When enabled, prints the full file content to the build log before and after the replacement. |  | `false` |
 | `notfound_exit` | When enabled, the step fails if the current value is not found in the target file. Disable this to allow the step to succeed even if no replacement was made. |  | `true` |
-| `use_sudo` | When enabled, the step retries reading and writing the target file with `sudo` if it hits a permission error.  This is required on newer stacks (such as the 2026 Linux stack) where the step runs as the non-root `ubuntu` user and the target file is owned by `root`. Disable this if `sudo` is unavailable in your environment or you want permission errors to fail the step directly. |  | `true` |
+| `use_sudo` | When enabled, the step retries reading and writing the target file with `sudo` if it hits a permission error.  This is required on stacks where the step runs as the non-root user and the target file is owned by `root`. Disable this if `sudo` is unavailable in your environment or you want permission errors to fail the step directly. |  | `true` |
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | `new_value` | The string that replaces all occurrences of the current value in the target file. | required |  |
 | `show_file` | When enabled, prints the full file content to the build log before and after the replacement. |  | `false` |
 | `notfound_exit` | When enabled, the step fails if the current value is not found in the target file. Disable this to allow the step to succeed even if no replacement was made. |  | `true` |
+| `use_sudo` | When enabled, the step retries reading and writing the target file with `sudo` if it hits a permission error.  This is required on newer stacks (such as the 2026 Linux stack) where the step runs as the non-root `ubuntu` user and the target file is owned by `root`. Disable this if `sudo` is unavailable in your environment or you want permission errors to fail the step directly. |  | `true` |
 </details>
 
 <details>

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -25,7 +25,8 @@ step_bundles:
             set -ex
             echo -n "$original_content" > "$test_file_path"
             if [ "$root_owned" == "true" ] ; then
-              sudo chown root:root "$test_file_path"
+              # Use numeric IDs for portability: gid 0 is `root` on Linux but `wheel` on macOS
+              sudo chown 0:0 "$test_file_path"
               sudo chmod 644 "$test_file_path"
             fi
 

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -112,7 +112,7 @@ workflows:
             and finally the third line
 
   test_replace_value_in_root_owned_file:
-    description: Tests that the step can change a value in a root-owned file via the sudo fallback. On the 2026 Linux stack the step runs as the non-root `ubuntu` user, so writing a root-owned file requires elevated privileges.
+    description: Tests that the step can change a value in a root-owned file via the sudo fallback. On stacks where the step runs as a non-root user, writing a root-owned file requires elevated privileges.
     steps:
     - bundle::setup:
         inputs:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -1,21 +1,15 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
-workflows:
-  test_replace_value:
-    description: Tests that a value is correctly replaced in a target file.
-    envs:
-    - TEST_FILE_PATH: ./test.txt
-    - ORIGINAL_TEST_FILE_CONTENT: |-
-        this is the first line
-        the second line
-        and finally the third line
-    - REPLACE_THIS: second
-    - REPLACE_WITH: 2nd
-    - EXPECTED_TEST_FILE_CONTENT_AFTER_REPLACE: |-
-        this is the first line
-        the 2nd line
-        and finally the third line
+step_bundles:
+  # Switches into ./_tmp and writes the test input file. Set root_owned to
+  # "true" to make the file root-owned and not writable by the current user,
+  # forcing the step to use its sudo fallback.
+  setup:
+    inputs:
+    - test_file_path: ""
+    - original_content: ""
+    - root_owned: "false"
     steps:
     - change-workdir:
         title: Switch working dir to test _tmp dir
@@ -29,70 +23,155 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            echo -n "$ORIGINAL_TEST_FILE_CONTENT" > "$TEST_FILE_PATH"
-    - path::../:
+            echo -n "$original_content" > "$test_file_path"
+            if [ "$root_owned" == "true" ] ; then
+              sudo chown root:root "$test_file_path"
+              sudo chmod 644 "$test_file_path"
+            fi
+
+  # Runs the step under test against the generated file.
+  run_step:
+    inputs:
+    - test_file_path: ""
+    - replace_this: second
+    - replace_with: 2nd
+    - use_sudo: "true"
+    steps:
+    - path::./:
         run_if: "true"
         inputs:
         - show_file: "true"
-        - file: $TEST_FILE_PATH
-        - old_value: $REPLACE_THIS
-        - new_value: $REPLACE_WITH
+        - file: $test_file_path
+        - old_value: $replace_this
+        - new_value: $replace_with
+        - use_sudo: $use_sudo
+
+  # Asserts the target file matches the expected content after replacement.
+  verify:
+    inputs:
+    - test_file_path: ""
+    - expected_content: ""
+    steps:
     - script:
         title: Verify file content after replacement
         inputs:
         - content: |-
             #!/bin/bash
             set -ex
-            file_content="$(cat "$TEST_FILE_PATH")"
-            if [[ "$file_content" != "$EXPECTED_TEST_FILE_CONTENT_AFTER_REPLACE" ]] ; then
+            file_content="$(cat "$test_file_path")"
+            if [[ "$file_content" != "$expected_content" ]] ; then
               echo "File content did not match expected value!"
               exit 1
             fi
             echo "Perfect!"
 
-  test_notfound_exit:
-    description: Tests that the step fails when notfound_exit is true and the old value does not exist in the file.
+  # Runs a utility workflow that is expected to fail and asserts it does.
+  # Set skip_if_root to "true" for cases that can only fail as a non-root user.
+  expect_failure:
+    inputs:
+    - workflow: ""
+    - skip_if_root: "false"
     steps:
     - script:
-        title: Run step expecting failure, verify exit code
+        title: Run workflow expecting failure, verify exit code
         inputs:
         - content: |-
             #!/bin/bash
             set -x # Do not set -e: the inner bitrise run is expected to fail
-            bitrise run --config e2e/bitrise.yml _notfound_utility
+            if [ "$skip_if_root" == "true" ] && [ "$(id -u)" -eq 0 ] ; then
+              echo "Running as root: cannot exercise the non-root permission failure. Skipping."
+              exit 0
+            fi
+            bitrise run --config e2e/bitrise.yml "$workflow"
             if [ $? -ne 1 ] ; then
-              echo "Workflow was expected to fail but did not."
+              echo "Workflow ($workflow) was expected to fail but did not."
               exit 1
             fi
 
-  _notfound_utility:
-    envs:
-    - TEST_FILE_PATH: ./test.txt
-    - ORIGINAL_TEST_FILE_CONTENT: |-
-        this is the first line
-
-        and finally the third line
-    - REPLACE_THIS: second
-    - REPLACE_WITH: 2nd
+workflows:
+  test_replace_value:
+    description: Tests that a value is correctly replaced in a target file.
     steps:
-    - change-workdir:
-        title: Switch working dir to test _tmp dir
-        run_if: "true"
+    - bundle::setup:
         inputs:
-        - path: ./_tmp
-        - is_create_path: true
-    - script:
-        title: Generate test input file
+        - test_file_path: ./test.txt
+        - original_content: |-
+            this is the first line
+            the second line
+            and finally the third line
+    - bundle::run_step:
         inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            echo -n "$ORIGINAL_TEST_FILE_CONTENT" > "$TEST_FILE_PATH"
-    - path::../:
-        run_if: "true"
+        - test_file_path: ./test.txt
+    - bundle::verify:
         inputs:
-        - show_file: "true"
-        - file: $TEST_FILE_PATH
-        - old_value: $REPLACE_THIS
-        - new_value: $REPLACE_WITH
-        - notfound_exit: "true"
+        - test_file_path: ./test.txt
+        - expected_content: |-
+            this is the first line
+            the 2nd line
+            and finally the third line
+
+  test_replace_value_in_root_owned_file:
+    description: Tests that the step can change a value in a root-owned file via the sudo fallback. On the 2026 Linux stack the step runs as the non-root `ubuntu` user, so writing a root-owned file requires elevated privileges.
+    steps:
+    - bundle::setup:
+        inputs:
+        - test_file_path: ./root_owned.txt
+        - root_owned: "true"
+        - original_content: |-
+            this is the first line
+            the second line
+            and finally the third line
+    - bundle::run_step:
+        inputs:
+        - test_file_path: ./root_owned.txt
+        - use_sudo: "true"
+    - bundle::verify:
+        inputs:
+        - test_file_path: ./root_owned.txt
+        - expected_content: |-
+            this is the first line
+            the 2nd line
+            and finally the third line
+
+  test_no_sudo_root_owned_file_fails:
+    description: Tests that the step fails on a root-owned file when use_sudo is false, since the non-root user cannot write it without elevated privileges.
+    steps:
+    - bundle::expect_failure:
+        inputs:
+        - workflow: _no_sudo_utility
+        - skip_if_root: "true"
+
+  _no_sudo_utility:
+    steps:
+    - bundle::setup:
+        inputs:
+        - test_file_path: ./no_sudo_root_owned.txt
+        - root_owned: "true"
+        - original_content: |-
+            this is the first line
+            the second line
+            and finally the third line
+    - bundle::run_step:
+        inputs:
+        - test_file_path: ./no_sudo_root_owned.txt
+        - use_sudo: "false"
+
+  test_notfound_exit:
+    description: Tests that the step fails when notfound_exit is true and the old value does not exist in the file.
+    steps:
+    - bundle::expect_failure:
+        inputs:
+        - workflow: _notfound_utility
+
+  _notfound_utility:
+    steps:
+    - bundle::setup:
+        inputs:
+        - test_file_path: ./test.txt
+        - original_content: |-
+            this is the first line
+
+            and finally the third line
+    - bundle::run_step:
+        inputs:
+        - test_file_path: ./test.txt

--- a/main.go
+++ b/main.go
@@ -109,8 +109,8 @@ func (s Step) Run(cfg Config) error {
 }
 
 // readFile reads the target file, falling back to an elevated read (when
-// useSudo is set) if the step lacks permission. On the 2026 Linux stack the
-// step runs as the non-root `ubuntu` user, so root-owned files require sudo.
+// useSudo is set) if the step lacks permission. On stacks where the
+// step runs as a non-root user, root-owned files require sudo.
 func (s Step) readFile(path string, useSudo bool) ([]byte, error) {
 	content, err := os.ReadFile(path)
 	if err == nil {

--- a/main.go
+++ b/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"strings"
 
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
+	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/log"
 )
@@ -17,6 +22,7 @@ type Input struct {
 	NewValue     string `env:"new_value"`
 	ShowFile     bool   `env:"show_file"`
 	NotfoundExit bool   `env:"notfound_exit"`
+	UseSudo      bool   `env:"use_sudo"`
 }
 
 // Config holds validated step configuration.
@@ -26,18 +32,21 @@ type Config struct {
 	newValue     string
 	showFile     bool
 	notfoundExit bool
+	useSudo      bool
 }
 
 // Step implements the change-value step logic.
 type Step struct {
 	inputParser stepconf.InputParser
+	cmdFactory  command.Factory
 	logger      log.Logger
 }
 
 // NewStep creates a Step with injected dependencies.
-func NewStep(inputParser stepconf.InputParser, logger log.Logger) Step {
+func NewStep(inputParser stepconf.InputParser, cmdFactory command.Factory, logger log.Logger) Step {
 	return Step{
 		inputParser: inputParser,
+		cmdFactory:  cmdFactory,
 		logger:      logger,
 	}
 }
@@ -55,12 +64,13 @@ func (s Step) ProcessConfig() (Config, error) {
 		newValue:     input.NewValue,
 		showFile:     input.ShowFile,
 		notfoundExit: input.NotfoundExit,
+		useSudo:      input.UseSudo,
 	}, nil
 }
 
 // Run performs the value replacement in the target file.
 func (s Step) Run(cfg Config) error {
-	content, err := os.ReadFile(cfg.file)
+	content, err := s.readFile(cfg.file, cfg.useSudo)
 	if err != nil {
 		return fmt.Errorf("failed to read file (%s): %w", cfg.file, err)
 	}
@@ -90,11 +100,62 @@ func (s Step) Run(cfg Config) error {
 		s.logger.Printf("------------------------------------------")
 	}
 
-	if err := os.WriteFile(cfg.file, []byte(replaced), 0644); err != nil {
+	if err := s.writeFile(cfg.file, []byte(replaced), cfg.useSudo); err != nil {
 		return fmt.Errorf("failed to write file (%s): %w", cfg.file, err)
 	}
 
 	s.logger.Donef("Done")
+	return nil
+}
+
+// readFile reads the target file, falling back to an elevated read (when
+// useSudo is set) if the step lacks permission. On the 2026 Linux stack the
+// step runs as the non-root `ubuntu` user, so root-owned files require sudo.
+func (s Step) readFile(path string, useSudo bool) ([]byte, error) {
+	content, err := os.ReadFile(path)
+	if err == nil {
+		return content, nil
+	}
+	if !useSudo || !errors.Is(err, fs.ErrPermission) {
+		return nil, err
+	}
+
+	s.logger.Warnf("Permission denied reading %s, retrying with sudo", path)
+	var stdout, stderr bytes.Buffer
+	cmd := s.cmdFactory.Create("sudo", []string{"-n", "cat", path}, &command.Opts{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	if runErr := cmd.Run(); runErr != nil {
+		return nil, fmt.Errorf("elevated read failed (%s): %w", strings.TrimSpace(stderr.String()), runErr)
+	}
+	return stdout.Bytes(), nil
+}
+
+// writeFile writes content to the target file, falling back to an elevated
+// write (when useSudo is set) if the step lacks permission (see readFile for
+// context). `sudo tee` preserves the existing file's owner and mode; `-n`
+// prevents sudo from blocking on a password prompt (and from consuming the
+// piped content).
+func (s Step) writeFile(path string, content []byte, useSudo bool) error {
+	err := os.WriteFile(path, content, 0644)
+	if err == nil {
+		return nil
+	}
+	if !useSudo || !errors.Is(err, fs.ErrPermission) {
+		return err
+	}
+
+	s.logger.Warnf("Permission denied writing %s, retrying with sudo", path)
+	var stderr bytes.Buffer
+	cmd := s.cmdFactory.Create("sudo", []string{"-n", "tee", path}, &command.Opts{
+		Stdin:  bytes.NewReader(content),
+		Stdout: io.Discard,
+		Stderr: &stderr,
+	})
+	if runErr := cmd.Run(); runErr != nil {
+		return fmt.Errorf("elevated write failed (%s): %w", strings.TrimSpace(stderr.String()), runErr)
+	}
 	return nil
 }
 
@@ -106,7 +167,8 @@ func run() int {
 	logger := log.NewLogger()
 	envRepository := env.NewRepository()
 	inputParser := stepconf.NewInputParser(envRepository)
-	step := NewStep(inputParser, logger)
+	cmdFactory := command.NewFactory(envRepository)
+	step := NewStep(inputParser, cmdFactory, logger)
 
 	cfg, err := step.ProcessConfig()
 	if err != nil {

--- a/step.yml
+++ b/step.yml
@@ -60,3 +60,13 @@ inputs:
     value_options:
     - "true"
     - "false"
+- use_sudo: "true"
+  opts:
+    title: Use sudo when elevated permissions are required
+    description: |-
+      When enabled, the step retries reading and writing the target file with `sudo` if it hits a permission error.
+
+      This is required on newer stacks (such as the 2026 Linux stack) where the step runs as the non-root `ubuntu` user and the target file is owned by `root`. Disable this if `sudo` is unavailable in your environment or you want permission errors to fail the step directly.
+    value_options:
+    - "true"
+    - "false"

--- a/step.yml
+++ b/step.yml
@@ -66,7 +66,7 @@ inputs:
     description: |-
       When enabled, the step retries reading and writing the target file with `sudo` if it hits a permission error.
 
-      This is required on newer stacks (such as the 2026 Linux stack) where the step runs as the non-root `ubuntu` user and the target file is owned by `root`. Disable this if `sudo` is unavailable in your environment or you want permission errors to fail the step directly.
+      This is required on stacks where the step runs as the non-root user and the target file is owned by `root`. Disable this if `sudo` is unavailable in your environment or you want permission errors to fail the step directly.
     value_options:
     - "true"
     - "false"

--- a/vendor/github.com/bitrise-io/go-utils/v2/command/command.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/command/command.go
@@ -1,0 +1,200 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/env"
+)
+
+// ErrorFinder ...
+type ErrorFinder func(out string) []string
+
+// Opts ...
+type Opts struct {
+	Stdout      io.Writer
+	Stderr      io.Writer
+	Stdin       io.Reader
+	Env         []string
+	Dir         string
+	ErrorFinder ErrorFinder
+}
+
+// Factory ...
+type Factory interface {
+	Create(name string, args []string, opts *Opts) Command
+}
+
+type factory struct {
+	envRepository env.Repository
+}
+
+// NewFactory ...
+func NewFactory(envRepository env.Repository) Factory {
+	return factory{envRepository: envRepository}
+}
+
+// Create ...
+func (f factory) Create(name string, args []string, opts *Opts) Command {
+	cmd := exec.Command(name, args...)
+	var collector *errorCollector
+
+	if opts != nil {
+		if opts.ErrorFinder != nil {
+			collector = &errorCollector{errorFinder: opts.ErrorFinder}
+		}
+
+		cmd.Stdout = opts.Stdout
+		cmd.Stderr = opts.Stderr
+		cmd.Stdin = opts.Stdin
+
+		// If Env is nil, the new process uses the current process's
+		// environment.
+		// If we pass env vars we want to append them to the
+		// current process's environment.
+		cmd.Env = append(f.envRepository.List(), opts.Env...)
+		cmd.Dir = opts.Dir
+	}
+	return &command{
+		cmd:            cmd,
+		errorCollector: collector,
+	}
+}
+
+// Command ...
+type Command interface {
+	PrintableCommandArgs() string
+	Run() error
+	RunAndReturnExitCode() (int, error)
+	RunAndReturnTrimmedOutput() (string, error)
+	RunAndReturnTrimmedCombinedOutput() (string, error)
+	Start() error
+	Wait() error
+}
+
+type command struct {
+	cmd            *exec.Cmd
+	errorCollector *errorCollector
+}
+
+// PrintableCommandArgs ...
+func (c command) PrintableCommandArgs() string {
+	return printableCommandArgs(false, c.cmd.Args)
+}
+
+// Run ...
+func (c *command) Run() error {
+	c.wrapOutputs()
+
+	if err := c.cmd.Run(); err != nil {
+		return c.wrapError(err)
+	}
+
+	return nil
+}
+
+// RunAndReturnExitCode ...
+func (c command) RunAndReturnExitCode() (int, error) {
+	c.wrapOutputs()
+	err := c.cmd.Run()
+	if err != nil {
+		err = c.wrapError(err)
+	}
+
+	exitCode := c.cmd.ProcessState.ExitCode()
+	return exitCode, err
+}
+
+// RunAndReturnTrimmedOutput ...
+func (c command) RunAndReturnTrimmedOutput() (string, error) {
+	outBytes, err := c.cmd.Output()
+	outStr := string(outBytes)
+	if err != nil {
+		if c.errorCollector != nil {
+			c.errorCollector.collectErrors(outStr)
+		}
+		err = c.wrapError(err)
+	}
+
+	return strings.TrimSpace(outStr), err
+}
+
+// RunAndReturnTrimmedCombinedOutput ...
+func (c command) RunAndReturnTrimmedCombinedOutput() (string, error) {
+	outBytes, err := c.cmd.CombinedOutput()
+	outStr := string(outBytes)
+	if err != nil {
+		if c.errorCollector != nil {
+			c.errorCollector.collectErrors(outStr)
+		}
+		err = c.wrapError(err)
+	}
+
+	return strings.TrimSpace(outStr), err
+}
+
+// Start ...
+func (c command) Start() error {
+	c.wrapOutputs()
+	return c.cmd.Start()
+}
+
+// Wait ...
+func (c command) Wait() error {
+	err := c.cmd.Wait()
+	if err != nil {
+		err = c.wrapError(err)
+	}
+
+	return err
+}
+
+func printableCommandArgs(isQuoteFirst bool, fullCommandArgs []string) string {
+	var cmdArgsDecorated []string
+	for idx, anArg := range fullCommandArgs {
+		quotedArg := fmt.Sprintf("\"%s\"", anArg)
+		if idx == 0 && !isQuoteFirst {
+			quotedArg = anArg
+		}
+		cmdArgsDecorated = append(cmdArgsDecorated, quotedArg)
+	}
+
+	return strings.Join(cmdArgsDecorated, " ")
+}
+
+func (c command) wrapError(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		errorLines := []string{}
+		if c.errorCollector != nil {
+			errorLines = c.errorCollector.errorLines
+		}
+
+		return NewExitStatusError(c.PrintableCommandArgs(), exitErr, errorLines)
+	}
+
+	return fmt.Errorf("executing command failed (%s): %w", c.PrintableCommandArgs(), err)
+}
+
+func (c command) wrapOutputs() {
+	if c.errorCollector == nil {
+		return
+	}
+
+	if c.cmd.Stdout != nil {
+		outWriter := io.MultiWriter(c.errorCollector, c.cmd.Stdout)
+		c.cmd.Stdout = outWriter
+	} else {
+		c.cmd.Stdout = c.errorCollector
+	}
+
+	if c.cmd.Stderr != nil {
+		errWriter := io.MultiWriter(c.errorCollector, c.cmd.Stderr)
+		c.cmd.Stderr = errWriter
+	} else {
+		c.cmd.Stderr = c.errorCollector
+	}
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/command/errorcollector.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/command/errorcollector.go
@@ -1,0 +1,18 @@
+package command
+
+type errorCollector struct {
+	errorLines  []string
+	errorFinder ErrorFinder
+}
+
+func (e *errorCollector) Write(p []byte) (n int, err error) {
+	e.collectErrors(string(p))
+	return len(p), nil
+}
+
+func (e *errorCollector) collectErrors(output string) {
+	lines := e.errorFinder(output)
+	if len(lines) > 0 {
+		e.errorLines = append(e.errorLines, lines...)
+	}
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/command/errors.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/command/errors.go
@@ -1,0 +1,48 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ExitStatusError ...
+type ExitStatusError struct {
+	readableReason  error
+	originalExitErr error
+}
+
+// NewExitStatusError ...
+func NewExitStatusError(printableCmdArgs string, exitErr *exec.ExitError, errorLines []string) error {
+	reasonMsg := fmt.Sprintf("command failed with exit status %d (%s)", exitErr.ExitCode(), printableCmdArgs)
+
+	errorOutput := strings.Join(errorLines, "\n")
+	if len(errorOutput) == 0 {
+		if len(exitErr.Stderr) != 0 {
+			errorOutput = string(exitErr.Stderr)
+		} else {
+			errorOutput = "check the command's output for details"
+		}
+	}
+
+	return &ExitStatusError{
+		readableReason:  fmt.Errorf("%s: %w", reasonMsg, errors.New(errorOutput)),
+		originalExitErr: exitErr,
+	}
+}
+
+// Error returns the formatted error message. Does not include the original error message (`exit status 1`).
+func (e *ExitStatusError) Error() string {
+	return e.readableReason.Error()
+}
+
+// Unwrap is needed for errors.Is and errors.As to work correctly.
+func (e *ExitStatusError) Unwrap() error {
+	return e.originalExitErr
+}
+
+// Reason returns the user-friendly error, to be used by errorutil.ErrorFormatter.
+func (e *ExitStatusError) Reason() error {
+	return e.readableReason
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3,6 +3,7 @@
 github.com/bitrise-io/go-steputils/v2/stepconf
 # github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36
 ## explicit; go 1.21
+github.com/bitrise-io/go-utils/v2/command
 github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/filedownloader
 github.com/bitrise-io/go-utils/v2/fileutil


### PR DESCRIPTION
Linux 2026 stack runs as `ubuntu` instead of `root`. If `ubuntu` does not have permission to write to the file, the step now provides the option to enable sudo (as a step input)